### PR TITLE
fix debuglog "any" types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { debuglog } from 'util';
 import RippleApiService from './api-v1/services/ripple-api';
 import { Server } from './server';
 import config from '../.secret_config';
@@ -7,7 +6,6 @@ const rippleApiService = new RippleApiService({server: config.server});
 console.log('Using rippled server:', config.server);
 
 const server = new Server({rippleApiService});
-server.setDebuglog(debuglog);
 server.listen().then((port) => {
   console.log('Listening on port:', port);
 });

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -27,8 +27,7 @@ when(mockedRippleApiService.api).thenReturn(rippleApi);
 
 const mockedRippleApiServiceInstance = instance(mockedRippleApiService);
 
-const server = new Server({rippleApiService: mockedRippleApiServiceInstance});
-server.setDebuglog(debuglog);
+const server = new Server({rippleApiService: mockedRippleApiServiceInstance, debuglog});
 const app = server.expressApp();
 
 afterEach(() => {


### PR DESCRIPTION
Move "debuglog" into a constructor parameter so that it's guarenteed to always exist (vs. possibly being undefined and throwing an error if `setDebuglog` is never called.

Also, removes an unnecessary private method.