### PR TITLE
Remove uncaughtException handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ As this server is still in active development, we do not recommend using it in p
 
 Considerations:
 - SSL/TLS must be used for all requests. An SSL/TLS termination proxy is recommended.
-- Restrictions should be made on signing, such as on the types of transactions, amount/velocity, and whitelisting of destinations. This feature is coming in the future.
+- Restrictions should be made on signing, such as on the types of transactions, amount/velocity, and whitelisting of destinations. This feature is coming in the future. 
+- If an error occurs, the server will exit to protect security & data integrity. We recommend using [nodemon](https://www.npmjs.com/package/nodemon) or [forever](https://www.npmjs.com/package/forever) to restart the server if any errors occur in production.
 
 ### Tutorial
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,20 +11,3 @@ server.setDebuglog(debuglog);
 server.listen().then((port) => {
   console.log('Listening on port:', port);
 });
-
-// Important: keeps server running after an exception
-process.on('uncaughtException', function (err) {
-  console.error('uncaughtException:', err);
-  // Example:
-  //
-  // Error: listen EADDRINUSE: address already in use :::3000
-  //
-  // Error: connect ECONNREFUSED 127.0.0.1:6006
-  // at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1054:14) {
-  //   errno: 'ECONNREFUSED',
-  //   code: 'ECONNREFUSED',
-  //   syscall: 'connect',
-  //   address: '127.0.0.1',
-  //   port: 6006
-  // }
-});


### PR DESCRIPTION
Once an exception is thrown, it's hard to trust the integrity of the environment. Code may have partially executed, data may be in a weird state, etc. Restarting the server whenever this happens is generally recommended in production to protect from any errors that come from  a malicious actor abusing this weird state.