### PR TITLE
fix startup output

### DIFF
--- a/src/api-v1/paths/accounts/{address}/info.ts
+++ b/src/api-v1/paths/accounts/{address}/info.ts
@@ -21,7 +21,7 @@ export default function(api: RippleAPI, log: Function): Operations {
     }
   };
 
-  async function GET(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function get(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     const parameters = Object.assign({},
       {'ledger_index': 'current'}, // default to 'current' (in-progress) ledger
       req.query,
@@ -52,7 +52,7 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   const operations = {
-    GET
+    get
   };
 
   return operations as Operations;

--- a/src/api-v1/paths/accounts/{address}/settings.ts
+++ b/src/api-v1/paths/accounts/{address}/settings.ts
@@ -10,7 +10,7 @@ import { ERRORS } from "../../../../errors";
 
 export default function(api: RippleAPI, log: Function): Operations {
 
-  async function GET(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function get(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     const parameters = Object.assign({},
       {'ledger_index': 'current'}, // default to 'current' (in-progress) ledger
       req.query,
@@ -45,7 +45,7 @@ export default function(api: RippleAPI, log: Function): Operations {
     });
   }
 
-  async function POST(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function post(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     const address = req.params.address; // TODO: parse X Address
     const settings = req.body.settings; // TODO: validate
     // const instructions = ...; // TODO: add this in the future, if use cases require it (for multisigning?)
@@ -91,7 +91,7 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   const operations = {
-    GET, POST
+    get, post
   };
 
   return operations as Operations;

--- a/src/api-v1/paths/accounts/{address}/transactions.ts
+++ b/src/api-v1/paths/accounts/{address}/transactions.ts
@@ -7,7 +7,7 @@ import { finishRes } from "../../../../finishRes";
 import { ERRORS } from "../../../../errors";
 
 export default function(api: RippleAPI, log: Function): Operations {
-  async function GET(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function get(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     const options = Object.assign({},
       req.query
     );
@@ -60,7 +60,7 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   const operations = {
-    GET
+    get
   };
 
   return operations as Operations;

--- a/src/api-v1/paths/apiDocs.ts
+++ b/src/api-v1/paths/apiDocs.ts
@@ -7,12 +7,12 @@ interface OpenAPIRequest extends Request {
 }
 
 export default function (): Operations {
-  function GET(req: OpenAPIRequest, res: Response, _next: NextFunction): void {
+  function get(req: OpenAPIRequest, res: Response, _next: NextFunction): void {
     res.json(req.apiDoc);
   }
 
   const operations = {
-    GET
+    get
   };
 
   return operations;

--- a/src/api-v1/paths/payments.ts
+++ b/src/api-v1/paths/payments.ts
@@ -10,7 +10,7 @@ import { finishRes } from "../../finishRes";
 import { ERRORS } from "../../errors";
 
 export default function(api: RippleAPI, log: Function): Operations {
-  async function POST(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function post(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     // TODO: parse X Address
     const address = req.body.payment.source_address;
     const accountWithSecret = config.accounts[address];
@@ -120,7 +120,7 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   const operations = {
-    POST
+    post
   };
 
   return operations as Operations;

--- a/src/api-v1/paths/ping.ts
+++ b/src/api-v1/paths/ping.ts
@@ -2,12 +2,12 @@ import { Request, Response, NextFunction } from "express";
 import { Operations } from '../../types';
 
 export default function (): Operations {
-  function GET(_req: Request, res: Response, _next: NextFunction): void {
+  function get(_req: Request, res: Response, _next: NextFunction): void {
     res.status(200).json();
   }
 
   const operations = {
-    GET
+    get
   };
 
   return operations;

--- a/src/api-v1/paths/servers/info.ts
+++ b/src/api-v1/paths/servers/info.ts
@@ -7,7 +7,7 @@ import { GetServerInfoResponse } from "ripple-lib/dist/npm/common/serverinfo";
 
 export default function(api: RippleAPI, log: Function): Operations {
 
-  async function GET(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function get(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     if (req.query.connect) {
       log('Connecting...');
       await api.connect();
@@ -36,6 +36,6 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   return {
-    GET
+    get
   };
 }

--- a/src/api-v1/paths/transactions/{transaction_id}.ts
+++ b/src/api-v1/paths/transactions/{transaction_id}.ts
@@ -23,7 +23,7 @@ export default function(api: RippleAPI, log: Function): Operations {
     }
   };
 
-  async function GET(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
+  async function get(req: Request, res: ValidatableResponse, _next: NextFunction): Promise<void> {
     // const parameters = Object.assign({},
     //   {'ledger_index': 'current'}, // default to 'current' (in-progress) ledger
     //   req.query,
@@ -61,7 +61,7 @@ export default function(api: RippleAPI, log: Function): Operations {
   }
 
   const operations = {
-    GET
+    get
   };
 
   return operations as Operations;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,8 @@ export interface ValidatableOperation /*extends OperationFunction*/ {
 }
 
 export interface Operations {
-  GET?: ValidatableOperation | Operation;
-  POST?: ValidatableOperation | Operation;
+  get?: ValidatableOperation | Operation;
+  post?: ValidatableOperation | Operation;
 }
 
 export interface ValidatableResponse extends Response {


### PR DESCRIPTION
On startup, I was getting this output:

```

This output: 
Using rippled server: wss://s.altnet.rippletest.net:51233
express-openapi: /servers/info.get has already been defined as /servers/info.GET. Ignoring the 2nd definition...
express-openapi: /ping.get has already been defined as /ping.GET. Ignoring the 2nd definition...
express-openapi: /payments.post has already been defined as /payments.POST. Ignoring the 2nd definition...
express-openapi: /apiDocs.get has already been defined as /apiDocs.GET. Ignoring the 2nd definition...
express-openapi: /transactions/{transaction_id}.get has already been defined as /transactions/{transaction_id}.GET. Ignoring the 2nd definition...
express-openapi: /accounts/{address}/transactions.get has already been defined as /accounts/{address}/transactions.GET. Ignoring the 2nd definition...
express-openapi: /accounts/{address}/settings.get has already been defined as /accounts/{address}/settings.GET. Ignoring the 2nd definition...
express-openapi: /accounts/{address}/info.get has already been defined as /accounts/{address}/info.GET. Ignoring the 2nd definition...
```

The `GET` & `get` naming was getting missed by openapi, this change renames the method to match the api-doc document and remove this warning.